### PR TITLE
update: add env.example and strapi url fallback in store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+STRAPI_API_URL=http://localhost:1337/api
+STRAPI_URL=http://localhost:1337/

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,4 @@
 export const state = () => ({
-  apiUrl: process.env.STRAPI_API_URL,
-  url: process.env.STRAPI_URL,
+  apiUrl: process.env.STRAPI_API_URL || "http://localhost:1337/api",
+  url: process.env.STRAPI_URL || "http://localhost:1337/",
 })


### PR DESCRIPTION
Added an `.env.example` file which contains default Strapi URLs

```

STRAPI_API_URL=http://localhost:1337/api
STRAPI_URL=http://localhost:1337/

```

This file can be renamed to `.env` in your local project.

Also, in case for some reason, you did not create the `.env` file to add the Strapi URLs, I included the default URLs in the `store` file - `./store/index.js`

```

export const state = () => ({
  apiUrl: process.env.STRAPI_API_URL || "http://localhost:1337/api",
  url: process.env.STRAPI_URL || "http://localhost:1337/",
})

```

To minimize errors, make sure your Strapi app is already created and running, with the following APIs / entities accessible:

```

['articles', 'projects', 'project_categories', 'categories', 'visitor_messages']

```

For more information, you can go to the **Step 4 - Set up front-end with NuxtJS and TailwindCSS** section in the [How to Build a Corporate Design Agency Site with NuxtJS and Strapi article](https://strapi.io/blog/how-to-build-a-corporate-design-agency-site-with-nuxt-js-and-strapi)
